### PR TITLE
Add constructor that allows specifying type

### DIFF
--- a/src/MemoryViews.jl
+++ b/src/MemoryViews.jl
@@ -105,6 +105,18 @@ is observed to be mutated.
 MutableMemoryView(::Unsafe, x::MemoryView{T}) where {T} =
     MutableMemoryView{T}(unsafe, x.ref, x.len)
 
+# Constructors that allows users to specify eltype explicitly, e.g.
+# ImmutableMemoryView{UInt8}([0x01])
+# With mutability specified
+function MemoryView{T, M}(x) where {T, M}
+    (MemoryView{X, M} where X)(x)::MemoryView{T, M}
+end
+
+# With mutability unspecified
+function MemoryView{T}(x) where T
+    MemoryView(x)::MemoryView{T}
+end
+
 """
     MemoryKind
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,12 @@ end
     s = Test.GenericString("abγδf")
     @test codeunits(s) == MemoryView(s)
     @test codeunits(s[2:(end - 2)]) == MemoryView(s)[2:(end - 1)]
+
+    x = [1,2,3]
+    @test MemoryView{Int}(x) isa MutableMemoryView{Int}
+    @test ImmutableMemoryView{Int}(x) isa ImmutableMemoryView{Int}
+    @test_throws TypeError MemoryView{UInt32}(x)
+    @test_throws TypeError ImmutableMemoryView{UInt32}(x)
 end
 
 @testset "Immutable views are immutable" begin


### PR DESCRIPTION
That is, allow `MemoryView{Int}([1,2,3])`.