### PR TITLE
Fix some bugs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -444,6 +444,10 @@ end
         @test split_unaligned(v, Val(8)) == split_at(v, 8)
         @test split_unaligned(v, Val(16)) == split_at(v, 16)
 
+        v = v[2:4]
+        @test split_unaligned(v, Val(16)) == split_at(v, length(v) + 1)
+        @test split_unaligned(v, Val(8)) == split_at(v, length(v) + 1)
+
         v = MemoryView(collect(0x0000:0x003f))[3:end]
         @test split_unaligned(v, Val(1)) == split_at(v, 1)
         @test split_unaligned(v, Val(4)) == split_at(v, 1)
@@ -544,6 +548,11 @@ end
     @test m1 != m2
     m2 = m2[1:(end - 1)]
     @test m1 == m2
+
+    # These only differ in the type metadata, make sure they are distinguished
+    m1 = MemoryView(Union{Int, UInt}[-1])
+    m2 = MemoryView(Union{Int, UInt}[typemax(UInt)])
+    @test m1 != m2
 end
 
 @testset "MemoryKind" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -553,6 +553,11 @@ end
     m1 = MemoryView(Union{Int, UInt}[-1])
     m2 = MemoryView(Union{Int, UInt}[typemax(UInt)])
     @test m1 != m2
+
+    m1 = MemoryView([1, 2, 3])
+    m2 = ImmutableMemoryView([1, 2, 3])
+    @test m1 == m2
+    @test m2 == m1
 end
 
 @testset "MemoryKind" begin


### PR DESCRIPTION
* Make sure == doesn't dispatch to memcmp if the mem's eltype is a union, since in that case the array's bits can be the same but its content differ due to the type metadata array. Also, test for this
* However, ensure that =='ing immutable and mutable arrays does dispatch to memchr, even if the two arrays type differ in mutability
* Fix an edge case in split_unaligned when no part of the array is aligned
* Minor refactor, using the internal truncate functions more. This change allows some branches to be omitted.
