### PR TITLE
Add specialization for getindex(::MemoryView, ::Base.OneTo)

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -101,6 +101,13 @@ function Base.getindex(v::MemoryView, idx::AbstractUnitRange)
     return typeof(v)(unsafe, newref, length(idx))
 end
 
+# Faster method, because we don't need to create a new memoryref, and also don't
+# need to handle the empty case.
+function Base.getindex(v::MemoryView, idx::Base.OneTo)
+    @boundscheck checkbounds(v, idx)
+    return typeof(v)(unsafe, v.ref, last(idx))
+end
+
 Base.getindex(v::MemoryView, ::Colon) = v
 Base.@propagate_inbounds Base.view(v::MemoryView, idx::AbstractUnitRange) = v[idx]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,6 +224,21 @@ end
         mem[3] = 10
         # No copying
         @test mem2 == [10, 1, 8]
+
+        # Base.OneTo
+        mem = MemoryView(b"abcdefg")
+        v = mem[Base.OneTo(3)]
+        @test v == b"abc"
+        v = mem[Base.OneTo(0)]
+        @test isempty(v)
+        v = mem[Base.OneTo(7)]
+        @test v === mem
+        mem = MemoryView("")
+        v = mem[Base.OneTo(0)]
+        @test mem === v
+
+        @test_throws BoundsError mem[Base.OneTo(8)]
+        @test_throws BoundsError mem[Base.OneTo(typemax(Int))]
     end
 
     @testset "Views of memviews" begin


### PR DESCRIPTION
This is slightly more efficient than the default implementation for Abstract- UnitRange.
