### PR TITLE
throw `LightBoundsError` instead of `BoundsError`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Aqua = "0.8.7"
 StringViews = "1"
 FixedSizeArrays = "1"
 LibDeflate = "0.4"
-LightBoundsErrors = "1"
+LightBoundsErrors = "1.1"
 Test = "1.11"
 julia = "1.11"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MemoryViews"
 uuid = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
-version = "0.3.7"
+version = "0.4.0"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
 version = "0.3.7"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
 
+[deps]
+LightBoundsErrors = "e21c612c-4641-4669-b9c3-3f4360ced9da"
+
 [weakdeps]
 StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 FixedSizeArrays = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
@@ -18,6 +21,7 @@ Aqua = "0.8.7"
 StringViews = "1"
 FixedSizeArrays = "1"
 LibDeflate = "0.4"
+LightBoundsErrors = "1"
 Test = "1.11"
 julia = "1.11"
 

--- a/src/MemoryViews.jl
+++ b/src/MemoryViews.jl
@@ -12,7 +12,7 @@ export MemoryView,
 
 public Mutable, Immutable, DelimitedIterator
 
-using LightBoundsErrors: checkbounds_lightboundserror
+using LightBoundsErrors: checkbounds_lightboundserror, throw_lightboundserror
 
 """
     Unsafe

--- a/src/MemoryViews.jl
+++ b/src/MemoryViews.jl
@@ -12,6 +12,8 @@ export MemoryView,
 
 public Mutable, Immutable, DelimitedIterator
 
+using LightBoundsErrors: checkbounds_lightboundserror
+
 """
     Unsafe
 

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -51,6 +51,10 @@ function Base.copy(x::MemoryView)
     return typeof(x)(unsafe, memoryref(newmem), x.len)
 end
 
+function Base.checkbounds(v::MemoryView, is...)
+    checkbounds_lightboundserror(v, is...)
+end
+
 function Base.getindex(v::MemoryView, i::Integer)
     @boundscheck checkbounds(v, i)
     ref = @inbounds memoryref(v.ref, i)

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -52,6 +52,6 @@ MemoryKind(::Type{<:ContiguousSubArray{T, N, P}}) where {T, N, P} = MemoryKind(P
 function MemoryView(s::ContiguousSubArray{T, N, P}) where {T, N, P}
     memview = MemoryView(parent(s)::P)
     inds = only(parentindices(s))
-    @boundscheck checkbounds(memview.ref.mem, inds)
+    @boundscheck checkbounds_lightboundserror(memview.ref.mem, inds)
     return @inbounds memview[inds]
 end

--- a/src/experimental.jl
+++ b/src/experimental.jl
@@ -78,7 +78,7 @@ julia> split_at(MemoryView(Int8[1, 2, 3]), 4)
 ```
 """
 function split_at(v::MemoryView, i::Int)
-    @boundscheck checkbounds(1:(lastindex(v) + 1), i)
+    @boundscheck checkbounds_lightboundserror(1:(lastindex(v) + 1), i)
     return (@inbounds(truncate(v, i - 1)), @inbounds(truncate_start(v, i)))
 end
 

--- a/src/experimental.jl
+++ b/src/experimental.jl
@@ -7,7 +7,7 @@ export split_first, split_last, split_at, split_unaligned
 
 Return the first element of `v` and all other elements as a new memory view.
 
-This function will throw a `BoundsError` if `v` is empty.
+This function will throw a `LightBoundsError` if `v` is empty.
 
 See also: [`split_last`](@ref)
 
@@ -22,7 +22,9 @@ julia> split_first(v[1:1])
 (0x01, UInt8[])
 
 julia> split_first(v[1:0])
-ERROR: BoundsError: attempt to access 0-element MutableMemoryView{UInt8} at index [1]
+ERROR: LightBoundsErrors.LightBoundsError: out-of-bounds indexing: `collection[1]`, where:
+* `typeof(collection) == MutableMemoryView{UInt8}`
+* `axes(collection) == (Base.OneTo(0),)`
 [...]
 ```
 """
@@ -36,7 +38,7 @@ end
 
 Return the last element of `v` and all other elements as a new memory view.
 
-This function will throw a `BoundsError` if `v` is empty.
+This function will throw a `LightBoundsError` if `v` is empty.
 
 See also: [`split_first`](@ref)
 
@@ -51,7 +53,9 @@ julia> split_last(v[1:1])
 (0x01, UInt8[])
 
 julia> split_last(v[1:0])
-ERROR: BoundsError: attempt to access 0-element MutableMemoryView{UInt8} at index [1]
+ERROR: LightBoundsErrors.LightBoundsError: out-of-bounds indexing: `collection[1]`, where:
+* `typeof(collection) == MutableMemoryView{UInt8}`
+* `axes(collection) == (Base.OneTo(0),)`
 [...]
 ```
 """
@@ -66,7 +70,7 @@ end
 Split a memory view into two at an index.
 
 The first will contain all indices in `1:i-1`, the second `i:end`.
-This function will throw a `BoundsError` if `i` is not in `1:end+1`.
+This function will throw a `LightBoundsError` if `i` is not in `1:end+1`.
 
 # Examples
 ```jldoctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using MemoryViews
 using Aqua
 using StringViews: StringView
 using LibDeflate: LibDeflate
+using LightBoundsErrors: LightBoundsError
 
 using MemoryViews: DelimitedIterator, Mutable, Immutable
 
@@ -212,7 +213,7 @@ end
 
         @test mem[3] == cu[3]
         for i in [-100, -4, -1, 0, length(cu) + 1, length(cu) + 100]
-            @test_throws BoundsError mem[i]
+            @test_throws LightBoundsError mem[i]
         end
     end
 
@@ -253,8 +254,8 @@ end
         v = mem[Base.OneTo(0)]
         @test mem === v
 
-        @test_throws BoundsError mem[Base.OneTo(8)]
-        @test_throws BoundsError mem[Base.OneTo(typemax(Int))]
+        @test_throws LightBoundsError mem[Base.OneTo(8)]
+        @test_throws LightBoundsError mem[Base.OneTo(typemax(Int))]
 
         # UInt indexing
         v = MemoryView([3, 4, 5, 6, 7])
@@ -474,8 +475,8 @@ end
             @test split_first(mem) == (mem[1], mem[2:end])
             @test split_last(mem) == (mem[end], mem[1:(end - 1)])
             mem = mem[1:0]
-            @test_throws BoundsError split_first(mem)
-            @test_throws BoundsError split_last(mem)
+            @test_throws LightBoundsError split_first(mem)
+            @test_throws LightBoundsError split_last(mem)
         end
 
         # Split empty mem at

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -397,15 +397,15 @@ end
         @test v1 == v2
         @test mem1 == mem2
 
-        @test_throws BoundsError copy!(MemoryView([1]), MemoryView([1, 2]))
-        @test_throws BoundsError copy!(MemoryView([1, 2]), MemoryView([1]))
+        @test_throws LightBoundsError copy!(MemoryView([1]), MemoryView([1, 2]))
+        @test_throws LightBoundsError copy!(MemoryView([1, 2]), MemoryView([1]))
 
         # Copyto!
         v1 = [4, 2, 6, 7, 9]
         v2 = [1, 5, 2, 3]
         copyto!(MemoryView(v1), MemoryView(v2))
         @test v1 == [1, 5, 2, 3, 9]
-        @test_throws BoundsError copyto!(MemoryView(v2), MemoryView(v1))
+        @test_throws LightBoundsError copyto!(MemoryView(v2), MemoryView(v1))
 
         # unsafe_copyto!
         v1 = [3, 6, 2, 1]
@@ -527,8 +527,8 @@ end
             @test findnext(isodd, mem, 0x04) === nothing
             @test findnext(isodd, mem, 10) === nothing
 
-            @test_throws BoundsError findnext(isodd, mem, 0)
-            @test_throws BoundsError findnext(isodd, mem, -1)
+            @test_throws LightBoundsError findnext(isodd, mem, 0)
+            @test_throws LightBoundsError findnext(isodd, mem, -1)
 
             @test findprev(isodd, mem, 4) == 3
             @test findprev(isodd, mem, 0x03) == 3
@@ -536,8 +536,8 @@ end
             @test findprev(isodd, mem, 0x00) === nothing
             @test findprev(isodd, mem, -10) === nothing
 
-            @test_throws BoundsError findprev(isodd, mem, 5)
-            @test_throws BoundsError findprev(isodd, mem, 7)
+            @test_throws LightBoundsError findprev(isodd, mem, 5)
+            @test_throws LightBoundsError findprev(isodd, mem, 7)
         end
 
         @testset "Memchr routines" begin
@@ -548,8 +548,8 @@ end
                 @test findnext(==(T(2)), mem, 3) == 5
                 @test findnext(==(T(7)), mem, 4) === nothing
                 @test findnext(==(T(2)), mem, 7) === nothing
-                @test_throws BoundsError findnext(iszero, mem, 0)
-                @test_throws BoundsError findnext(iszero, mem, -3)
+                @test_throws LightBoundsError findnext(iszero, mem, 0)
+                @test_throws LightBoundsError findnext(iszero, mem, -3)
 
                 @test findlast(iszero, mem) == 4
                 @test findprev(iszero, mem, 3) === nothing
@@ -559,7 +559,7 @@ end
                 @test findprev(==(T(9)), mem, 3) === nothing
                 @test findprev(==(T(2)), mem, -2) === nothing
                 @test findprev(iszero, mem, 0) === nothing
-                @test_throws BoundsError findprev(iszero, mem, 7)
+                @test_throws LightBoundsError findprev(iszero, mem, 7)
             end
             mem = MemoryView(Int8[2, 3, -1])
             @test findfirst(==(0xff), mem) === nothing


### PR DESCRIPTION
Context: While `BoundsError` is common in the Julia world, its use is problematic for compiler optimizations. More specifically, Julia is gaining the ability to eliminate heap allocations as of recently, even for code that is not eliminated by dead code elimination or eliminated by constant folding. After the compiler gains interprocedural escape analysis capabilities, elimination of heap allocations should become applicable more often. The problem with `BoundsError` is that a `BoundsError` value holds a reference to the array that was attempted to be indexed out-of-bounds. Thus a `BoundsError` throw escapes the value of the array. Thus a `BoundsError` throw makes the elimination of the underlying heap allocation impossible, unless the throw is first eliminated by `@inbounds` or by other compiler optimizations.

The `LightBoundsError` exception from package [LightBoundsErrors.jl](https://github.com/JuliaArrays/LightBoundsErrors.jl) addresses this by storing `typeof(array)` and `axes(array)` instead of storing `array`. The new package is already adopted as a dependency by [FixedSizeArrays.jl](https://github.com/JuliaArrays/FixedSizeArrays.jl).

Switching from `BoundsError` to `LightBoundsError` could hypothetically break a dependent of MemoryViews, in case a dependent branches on something like `exception isa BoundsError` while error handling.

Auto-checklist:

- [x] I have updated any relevant documentation and docstrings.
- [ ] I have added unit tests, and the CodeCov bot shows tests cover my new code.
- [ ] I have mentioned my changes in the CHANGELOG.md file.
