### PR TITLE
Remove `Base.memoryref(::ImmutableMemoryView)`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to LLMs when working with code in this repository.
 
 ## Project Overview
 
-MemoryViews.jl provides `MemoryView`, a low-level view into `Memory{T}` for Julia ≥ 1.11. It's a `DenseVector{T}` subtype representing a `MemoryRef{T}` + length, with static mutability tracking via type parameter (`Mutable`/`Immutable`). The package also defines the `MemoryKind` trait for dispatch on memory-backed types.
+MemoryViews.jl provides `MemoryView`, a low-level view into `Memory{T}` for Julia ≥ 1.11. It's a `DenseVector{T}` subtype representing a `MemoryRef{T}` + length, with static mutability tracking via type parameter (`Mutable`/`Immutable`).
 
 ## Commands
 
@@ -24,7 +24,6 @@ Set `--check-bounds=yes` to force boundschecking when running experiments.
 
 **Core types** (defined in `src/MemoryViews.jl`):
 - `MemoryView{T, M}` where `M ∈ {Mutable, Immutable}` — the main type
-- `MemoryKind` trait: `IsMemory{T}` / `NotMemory` for dispatch
 
 **Source files**:
 - `construction.jl` — constructors from Array, Memory, String, SubArray, CodeUnits
@@ -40,5 +39,4 @@ Set `--check-bounds=yes` to force boundschecking when running experiments.
 - Slicing creates views into the same memory (no allocation)
 - Performance-critical paths use `@ccall` to libc (`memset`, `memcmp`, `memchr`, `memrchr`) with `GC.@preserve`
 - Version-conditional code for Julia 1.12+ vs 1.13+ (e.g., `Base.memoryindex` for `parentindices`)
-- Trait-based dispatch pattern: define `foo(x)` → `foo(MemoryKind(typeof(x)), x)` → specialized on `IsMemory`/`NotMemory`
 - `@boundscheck`/`@inbounds` used throughout for safe-by-default with opt-in elision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Any new features, or breaking changes, will be written in this file.
 Bugfixes, internal refactors, documentation improvements and style changes will
 not be mentioned here, because they do not impact how the package is to be used.
 
+## 0.5.0
+### Breaking changes
+* `Base.memoryref(::ImmutableMemoryView)` now throws a `MethodError`.
+  This method was unsafe, and so has been removed.
+  To get a `MemoryRef` from `ImmutableMemory`, use the new `unsafe_memoryref` function.
+
 ## 0.4.2
 * Added `MemoryViews.truncate(v, i)` similar to `v[1:i]`, but may be more efficient.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ not be mentioned here, because they do not impact how the package is to be used.
 
 ## 0.5.0
 ### Breaking changes
+* `DelimitedIterator{T, M}` is now `DelimitedIterator{T, M, D}`, where `D` is
+  the delimiter type. `split_each(data, d)` now accepts any delimiter satisfying
+  `d isa eltype(MemoryView(data))`, including concrete delimiters for abstract
+  element types.
 * `Iterators.reverse` now preserves the mutability of its input `MemoryView`.
   Applying it twice returns the original view, rather than always returning an
   `ImmutableMemoryView`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ not be mentioned here, because they do not impact how the package is to be used.
 ### Breaking changes
 * `Base.memoryref(::ImmutableMemoryView)` now throws a `MethodError`.
   This method was unsafe, and so has been removed.
-  To get a `MemoryRef` from `ImmutableMemory`, use the new `unsafe_memoryref` function.
+  To get a `MemoryRef` from `ImmutableMemoryView`, use the new `unsafe_memoryref` function.
+* Removed the `MemoryKind` interface, including the `IsMemory` and `NotMemory`
+  types and the `inner(::IsMemory)` function. Dispatch directly on `MemoryView`
+  instead.
 
 ## 0.4.2
 * Added `MemoryViews.truncate(v, i)` similar to `v[1:i]`, but may be more efficient.
@@ -86,6 +89,4 @@ Various fixes and optimizations.
 * Add functions `split_first`, `split_last`, `split_at` and `split_unaligned`
 * Add a more correct implementation of `Base.mightalias` for memory views and
   some types of arrays
-
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ not be mentioned here, because they do not impact how the package is to be used.
 
 ## 0.5.0
 ### Breaking changes
+* `Iterators.reverse` now preserves the mutability of its input `MemoryView`.
+  Applying it twice returns the original view, rather than always returning an
+  `ImmutableMemoryView`.
 * `Base.memoryref(::ImmutableMemoryView)` now throws a `MethodError`.
   This method was unsafe, and so has been removed.
   To get a `MemoryRef` from `ImmutableMemoryView`, use the new `unsafe_memoryref` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ not be mentioned here, because they do not impact how the package is to be used.
 * `Base.memoryref(::ImmutableMemoryView)` now throws a `MethodError`.
   This method was unsafe, and so has been removed.
   To get a `MemoryRef` from `ImmutableMemoryView`, use the new `unsafe_memoryref` function.
+* Removed `parent(::ImmutableMemoryView)`, which exposed mutable backing memory
+  from a read-only view. `parent(::MutableMemoryView)` remains available.
+* `Base.cconvert(::Type{<:Ptr}, ::MemoryView)` now returns the input view.
+  Use `Base.unsafe_convert` or `pointer` to obtain a pointer.
+* The `MemoryView` fields and exact representation are now explicitly internal
+  API. The type remains immutable and the same size as a `MemoryRef` and an
+  `Int` combined.
 * Removed the `MemoryKind` interface, including the `IsMemory` and `NotMemory`
   types and the `inner(::IsMemory)` function. Dispatch directly on `MemoryView`
   instead.
@@ -89,4 +96,3 @@ Various fixes and optimizations.
 * Add functions `split_first`, `split_last`, `split_at` and `split_unaligned`
 * Add a more correct implementation of `Base.mightalias` for memory views and
   some types of arrays
-

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MemoryViews"
 uuid = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://biojulia.github.io/MemoryViews.jl/dev)
 [![](https://codecov.io/gh/BioJulia/MemoryViews.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/MemoryViews.jl)
 
-This package implements `MemoryView`, a simple, low-level view into a chunk of `Memory`, as well as the `MemoryKind` trait to guide dispatch of generic methods to memory views.
+This package implements `MemoryView`, a simple, low-level view into a chunk of `Memory`.
 It is intended to be used as a foundational base for other packages.
 
 To learn how to use the package, [read the documentation](https://biojulia.github.io/MemoryViews.jl/dev/)
@@ -37,22 +37,21 @@ fst = mem1[1]
 reverse!(mem2) # ... etc
 ```
 
-### Dispatching to MemoryView
+### Reusing a MemoryView implementation
 ```julia
 function foo(x::ImmutableMemoryView)
     # low-level implementation
 end
 
-function foo(::NotMemory, x::AbstractArray)
+function foo(x::AbstractArray)
     # slow, generic fallback
 end
 
-# Dispatch with the `MemoryKind` trait
-foo(::IsMemory, x) = foo(ImmutableMemoryView(x))
-foo(x) = foo(MemoryKind(typeof(x)), x)
+# Forward supported memory-backed types to the low-level implementation
+foo(x::Union{Vector, Memory}) = foo(ImmutableMemoryView(x))
 
 # Optionally: Also support strings
-foo(x::AbstractString) = foo(codeunits(x))
+foo(x::Union{String, SubString{String}}) = foo(ImmutableMemoryView(x))
 ```
 
 ## API differences from `Memory`

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(;
         "MemoryViews" => "index.md",
         "MemoryViews in interfaces" => "interfaces.md",
         "MemoryViews in Base" => "base.md",
+        "Migrating from 0.4 to 0.5" => "migration.md",
         "Reference" => "reference.md",
     ],
     authors = "Jakob Nybo Nissen",

--- a/docs/src/base.md
+++ b/docs/src/base.md
@@ -31,13 +31,6 @@ Mutable and immutable memory views are statically distinguished, such that users
 can write methods that only take mutable memory views.
 This will statically prevent users from accidentally mutating e.g. strings.
 
-#### MemoryKind
-The MemoryKind trait is used because constructing a MemoryView only for dispatch purposes
-may not be able to be optimised away by the compiler for some types (currently, strings).
-
-MemoryKind could be replaced with a function that returned `nothing`, or the correct
-MemoryView type directly, but it's nicer to dispatch on `::MemoryKind` than on `::Union{Nothing, Type{<:MemoryView}}`.
-
 ## Limitations
 * Many optimised fast methods for more established types like `Vector` are missing for `MemoryView`.
   These are added over time. Please make an issue or a PR as you encounter missing methods.
@@ -54,7 +47,6 @@ MemoryView type directly, but it's nicer to dispatch on `::MemoryKind` than on `
 In `examples/alternative.jl`, there is an implementation where a `MemoryView` is just a pointer and a length.
 This makes it nearly identical to `Random.UnsafeView`, however, compared to `UnsafeView`, this proposal has:
 
-* The `MemoryKind` trait, useful to control dispatch to functions that can treat arrays _as being memory_
 * The distinction between mutable and immutable memory views
 
 Overall, I like the alternative proposal less. Raw pointers are bad for safety and ergonomics, and they interact

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,14 +14,17 @@ The `MemoryView` type is a useful low-level building block for code that operate
 * Low-overhead, efficient methods
 * A safer alternative to pointers
 
-The `MemoryView` type has the following layout:
+`MemoryView{T, M}` is guaranteed to be immutable and to have the same size as a
+`MemoryRef{T}` and an `Int` combined:
 
 ```julia
-struct MemoryView{T, M} <: DenseVector{T}
-    ref::MemoryRef{T},
-    len::Int
-end
+!ismutabletype(MemoryView{T, M})
+sizeof(MemoryView{T, M}) == sizeof(MemoryRef{T}) + sizeof(Int)
 ```
+
+Its fields are internal and are not part of the public API. Use `length`,
+`Base.memoryref` for mutable views, [`unsafe_memoryref`](@ref) when explicitly
+unsafe access is necessary, or `pointer` rather than accessing fields directly.
 
 The `M` parameter is either `Mutable` or `Immutable`, which are unexported but public types defined in this package.
 MemoryViews also provide the following aliases for convenience:

--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -15,10 +15,10 @@ Obviously, writing the same implementation for each of these types is wasteful.
 Unfortunately, Julia's system of abstract types are poorly equipped to handle this.
 This is because abstract types represent shared _behaviour_, whereas in this case, what unites these many different types are the underlying _representation_ - exactly the thing that abstract types want to paper over!
 
-MemoryViews.jl addresses this by introducing two types: At the bottom of abstraction, the simple `MemoryView` type is most basic, unified instantiation of the underlying representation (a chunk of memory).
-At the top, the `MemoryKind` trait controls dispatch such that the low-level `MemoryView` implementation is called for the right types.
-The idea is that whenever you write a method that operates on "just" a chunk of memory, you implement it for `MemoryView`.
-Then, you write methods with `MemoryKind` to make sure all the proper function calls gets dispatched to your `MemoryView` implementation.
+MemoryViews.jl addresses this with the simple `MemoryView` type: a unified
+representation of a chunk of memory. Whenever a method operates on "just" a
+chunk of memory, implement it for `MemoryView`. Other supported input types can
+forward explicitly to that implementation.
 
 !!! tip
     Even if you only ever intend a method to work for, say, `Vector`, it can still be a good idea to implement it for `MemoryView`.
@@ -27,56 +27,27 @@ Then, you write methods with `MemoryKind` to make sure all the proper function c
     Second, you can implement the method for `ImmutableMemoryView`, letting both caller and callee know that the argument is not being mutated.
     Third, after implementing your method for `MemoryView`, it may be easy to also make your method work for `Memory` and other memory-backed types!
 
-## The `MemoryKind` trait
-`MemoryKind` answers the question: Can instances of a type be treated as equal to its own memory view?
-For a type `T`, `MemoryKind(T)` returns one of two types:
-* `NotMemory()` if `T`s are not equivalent to its own memory. Examples include `Int`, which has no memory representation because
-  they are not heap allocated, and `String`, which _are_ backed by memory, but which are semantically different from an `AbstractVector`
-  containing its bytes.
-* `IsMemory{M}()` where `M` is a concrete subtype of `MemoryView`, if instances of `T` _are_ equivalent to their own memory.
-  Examples include `Vector`s and `Codeunits{String}`. For these objects, it's the case that `x == MemoryView(x)`.
-
-```jldoctest
-julia> MemoryKind(Vector{Union{Int32, UInt32}})
-IsMemory{MutableMemoryView{Union{Int32, UInt32}}}()
-
-julia> MemoryKind(Matrix{String}) # dimension mismatch, not equal
-NotMemory()
-
-julia> MemoryKind(SubString{String})
-NotMemory()
-```
-
 ## Implementing `MemoryView` interfaces
-When implementing a method that has a fast-past for memory-like types, you typically want to
-* At the top level, dispatch on `MemoryKind` of your argument to funnel the memory-like objects into
-  your optimised `MemoryView` function
-* At the low level, use `MemoryView` for the implementation of the optimised version
+When implementing a method with a fast path for memory-backed types, define the
+optimized implementation on `MemoryView`. Add forwarding methods for each input
+type whose semantics are appropriate for your function, and retain a generic
+fallback when needed.
 
 An example could be:
 ```julia
-# Dispatch on `MemoryKind`
-my_hash(x) = my_hash(MemoryKind(typeof(x)), x)
-
-# For objects that are bytes, call the function taking only the memory
-# representation of `x`
-my_hash(::IsMemory{<:MemoryView{UInt8}}, x) = my_hash(ImmutableMemoryView(x))
-
-# IsMemory with eltype other than UInt8 can't use the fast low-level function
-my_hash(::IsMemory, x) = my_hash(NotMemory(), x)
-
-function my_hash(::NotMemory, x)
-    # fallback implementation
-end
-
 function my_hash(mem::ImmutableMemoryView{UInt8})
     # some optimised low-level memory manipulation with `mem` of bytes
 end
 
-# Handle e.g. strings separately, since they are not semantically equal to
-# an array of elements in memory, but for this method in particular,
-# we want to treat strings as if they are.
-function my_hash(x::Union{String, SubString{String}})
-    my_hash(MemoryView(x))
-end
+# Forward types supported by this operation.
+my_hash(x::Union{Vector{UInt8}, Memory{UInt8}}) = my_hash(ImmutableMemoryView(x))
+my_hash(x::Union{String, SubString{String}}) = my_hash(ImmutableMemoryView(x))
+
+# Generic fallback.
+my_hash(x) = generic_hash(x)
 ```
+
+This explicit dispatch is useful because having a `MemoryView` constructor does
+not by itself mean that an object has the same semantics as its memory
+representation. For example, a `String` can be viewed as bytes, but is not an
+`AbstractVector{UInt8}`.

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -33,6 +33,55 @@ The caller is responsible for ensuring that the resulting reference is not used
 to mutate memory assumed to be immutable. Prefer keeping APIs in terms of
 `ImmutableMemoryView` when access to the underlying `MemoryRef` is not required.
 
+## Accessing parent memory
+
+The specialized `parent(::ImmutableMemoryView)` method has been removed because
+it returned mutable `Memory` from a read-only view. Base's generic
+`parent(::AbstractArray)` method instead returns the immutable view itself.
+`parent(::MutableMemoryView)` continues to return its backing `Memory`.
+
+Code that truly needs the backing memory of an immutable view must first make
+the unsafe operation explicit:
+
+```julia
+view = MemoryView("abc")
+ref = unsafe_memoryref(view)
+memory = parent(ref) # On Julia versions defining parent(::MemoryRef)
+```
+
+The returned memory must not be mutated when it backs data assumed to be
+immutable, such as a `String`.
+
+## Pointer conversion
+
+`Base.cconvert(Ptr{T}, view)` now returns `view` itself, keeping the owning
+object rooted during a foreign call. Use `Base.unsafe_convert` for the second
+conversion step, or call `pointer` directly:
+
+```julia
+converted = Base.cconvert(Ptr{UInt8}, view)
+ptr = Base.unsafe_convert(Ptr{UInt8}, converted)
+
+# Equivalent when the caller manages preservation:
+ptr = pointer(view)
+```
+
+Previously, `cconvert` returned the underlying `MemoryRef`.
+
+## Internal fields
+
+The field names of `MemoryView` are no longer public API. Replace direct field
+access with the corresponding interface:
+
+* Replace `view.len` with `length(view)`.
+* Replace `view.ref` with `Base.memoryref(view)` for mutable views.
+* For an immutable view, use `unsafe_memoryref(view)` only when explicitly
+  unsafe access is necessary.
+
+`MemoryView{T, M}` remains guaranteed to be immutable and to have the same size
+as a `MemoryRef{T}` and an `Int` combined. Its field count, field order, field
+types, and field names are internal.
+
 ## Removal of the `MemoryKind` interface
 
 The `MemoryKind` trait and its `IsMemory` and `NotMemory` types have been

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -14,14 +14,14 @@ written for MemoryViews 0.4.
 particular, mutating a reference into storage assumed to be immutable, such as
 the storage backing a `String`, can cause undefined behavior.
 
-Code that operates on a [`MutableMemoryView`](@ref) does not need to change:
+Code that operates on a `MutableMemoryView` does not need to change:
 
 ```julia
 view = MemoryView([1, 2, 3])
 ref = Base.memoryref(view)
 ```
 
-If code must obtain a `MemoryRef` from an [`ImmutableMemoryView`](@ref), replace
+If code must obtain a `MemoryRef` from an `ImmutableMemoryView`, replace
 `Base.memoryref(view)` with [`unsafe_memoryref(view)`](@ref):
 
 ```julia
@@ -32,3 +32,30 @@ ref = unsafe_memoryref(view)
 The caller is responsible for ensuring that the resulting reference is not used
 to mutate memory assumed to be immutable. Prefer keeping APIs in terms of
 `ImmutableMemoryView` when access to the underlying `MemoryRef` is not required.
+
+## Removal of the `MemoryKind` interface
+
+The `MemoryKind` trait and its `IsMemory` and `NotMemory` types have been
+removed, along with the trait-specific `inner` function. Code should dispatch
+directly on `MemoryView` instead.
+
+For example, replace trait-based dispatch:
+
+```julia
+process(x) = process(MemoryKind(typeof(x)), x)
+process(::IsMemory, x) = process(ImmutableMemoryView(x))
+process(::NotMemory, x) = fallback(x)
+```
+
+with methods for memory views and explicit forwarding methods for other
+supported inputs:
+
+```julia
+process(x::ImmutableMemoryView) = optimized_implementation(x)
+process(x::Union{Vector, Memory}) = process(ImmutableMemoryView(x))
+process(x) = fallback(x)
+```
+
+Packages that extended `MemoryKind(::Type{T})` should remove those methods. A
+`MemoryView(::T)` constructor may still be provided when `T` is backed by dense,
+contiguous memory.

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -7,6 +7,24 @@ CurrentModule = MemoryViews
 This page lists the breaking changes in MemoryViews 0.5 and how to update code
 written for MemoryViews 0.4.
 
+## Delimiter type parameter
+
+`DelimitedIterator{T, M}` now has a third type parameter,
+`DelimitedIterator{T, M, D}`, which stores the delimiter's type separately from
+the input element type `T`. `split_each(data, d)` now checks
+`d isa eltype(MemoryView(data))` instead of requiring exact type equality.
+For example, this previously rejected input now works:
+
+```julia
+collect(split_each(AbstractString["a", "b"], "")) # [["a", "b"]]
+```
+
+Code using `split_each` needs no changes. Dispatch on
+`DelimitedIterator{T, M}` still matches all delimiter types. If constructing the
+iterator directly with explicit type parameters, replace
+`DelimitedIterator{T, M}(view, d)` with
+`DelimitedIterator{T, M, typeof(d)}(view, d)`, or use `split_each(view, d)`.
+
 ## Reverse iteration preserves mutability
 
 `Iterators.reverse` now stores the original `MemoryView`, preserving its

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,0 +1,34 @@
+```@meta
+CurrentModule = MemoryViews
+```
+
+# Migrating from 0.4 to 0.5
+
+This page lists the breaking changes in MemoryViews 0.5 and how to update code
+written for MemoryViews 0.4.
+
+## Accessing the `MemoryRef` of an immutable view
+
+`Base.memoryref(::ImmutableMemoryView)` has been removed. The returned
+`MemoryRef` permits mutation, even when it comes from an immutable view. In
+particular, mutating a reference into storage assumed to be immutable, such as
+the storage backing a `String`, can cause undefined behavior.
+
+Code that operates on a [`MutableMemoryView`](@ref) does not need to change:
+
+```julia
+view = MemoryView([1, 2, 3])
+ref = Base.memoryref(view)
+```
+
+If code must obtain a `MemoryRef` from an [`ImmutableMemoryView`](@ref), replace
+`Base.memoryref(view)` with [`unsafe_memoryref(view)`](@ref):
+
+```julia
+view = MemoryView("abc")
+ref = unsafe_memoryref(view)
+```
+
+The caller is responsible for ensuring that the resulting reference is not used
+to mutate memory assumed to be immutable. Prefer keeping APIs in terms of
+`ImmutableMemoryView` when access to the underlying `MemoryRef` is not required.

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -7,6 +7,23 @@ CurrentModule = MemoryViews
 This page lists the breaking changes in MemoryViews 0.5 and how to update code
 written for MemoryViews 0.4.
 
+## Reverse iteration preserves mutability
+
+`Iterators.reverse` now stores the original `MemoryView`, preserving its
+mutability. Applying it twice returns the original view; previously, the result
+was always an `ImmutableMemoryView`, even for mutable input.
+
+```julia
+view = MemoryView([1, 2, 3])
+restored = Iterators.reverse(Iterators.reverse(view))
+restored === view # true
+restored[1] = 4 # Mutates the original backing array
+```
+
+If code relied on the result being immutable, convert it explicitly with
+`ImmutableMemoryView(restored)`. Immutable inputs still return the original
+immutable view after reversing twice.
+
 ## Accessing the `MemoryRef` of an immutable view
 
 `Base.memoryref(::ImmutableMemoryView)` has been removed. The returned

--- a/examples/find.jl
+++ b/examples/find.jl
@@ -1,11 +1,7 @@
+using MemoryViews
+
 # Findfirst is implemented in terms of findnext
 my_findfirst(p, haystack) = my_findnext(p, haystack, firstindex(haystack))
-
-# When the predicate is looking for a single byte, we dispatch to see
-# if the haystack is a chunk of memory. In that case, we can use memchr
-function my_findnext(p::Base.Fix2{<:Union{typeof(==), typeof(isequal)}, UInt8}, haystack, k)
-    return _my_findnext(MemoryKind(typeof(haystack)), p, haystack, k)
-end
 
 # The generic: Use fallback
 my_findnext(p, haystack, i) = _my_findnext(p, haystack, i)
@@ -20,9 +16,7 @@ function _my_findnext(p, haystack, i)
     return nothing
 end
 
-# String implementation - strings are not IsMemory, but
-# we can still use the MemoryViews interface to implement
-# char searching.
+# We can use a MemoryView to implement character searching in strings.
 function my_findnext(
         p::Base.Fix2{<:Union{typeof(==), typeof(isequal)}, <:AbstractChar},
         s::Union{String, SubString{String}},
@@ -48,22 +42,28 @@ function my_findnext(
     return nothing
 end
 
-# Fallback - if the haystack is not IsMemory of bytes, we use the fallback definiion
-function _my_findnext(::MemoryKind, p, haystack, i)
-    return _my_findnext(p, haystack, i)
-end
-
-# If it is bytes, we can convert the haystack to an ImmutableMemoryView,
-# and use the memory view's optimised method
+# Byte memory views use the optimized method directly.
 function _my_findnext(
-        ::IsMemory{<:MemoryView{UInt8}},
         p::Base.Fix2{<:Union{typeof(==), typeof(isequal)}, UInt8},
-        haystack,
+        haystack::MemoryView{UInt8},
         i,
     )
     ind = Int(i)::Int - Int(firstindex(haystack))::Int + 1
     ind < 1 && throw(BoundsError(haystack, i))
     return find_next_byte(p.x, ImmutableMemoryView(haystack), ind)
+end
+
+# Explicitly forward supported memory-backed byte containers.
+const ContiguousByteSubArray = SubArray{
+    UInt8, N, P, I, true,
+} where {N, P, I <: Union{Tuple{Integer}, Tuple{AbstractUnitRange}}}
+
+function my_findnext(
+        p::Base.Fix2{<:Union{typeof(==), typeof(isequal)}, UInt8},
+        haystack::Union{Vector{UInt8}, Memory{UInt8}, Base.CodeUnits{UInt8}, ContiguousByteSubArray},
+        i,
+    )
+    return _my_findnext(p, ImmutableMemoryView(haystack), i)
 end
 
 # Wrapper around memchr.

--- a/ext/FixedSizeArraysExt.jl
+++ b/ext/FixedSizeArraysExt.jl
@@ -1,9 +1,8 @@
 module FixedSizeArraysExt
 
 using FixedSizeArrays: FixedSizeArray
-using MemoryViews: MemoryViews, MemoryView, MemoryKind, MutableMemoryView
+using MemoryViews: MemoryViews, MemoryView
 
-MemoryViews.MemoryKind(::Type{<:FixedSizeArray{T, N, M}}) where {T, N, M} = MemoryKind(M)
 MemoryViews.MemoryView(x::FixedSizeArray) = MemoryView(parent(x))
 
 end # module

--- a/ext/StringViewsExt.jl
+++ b/ext/StringViewsExt.jl
@@ -1,9 +1,8 @@
 module StringViewsExt
 
 using StringViews: StringView
-import MemoryViews: MemoryView, MemoryKind
+import MemoryViews: MemoryView
 
 MemoryView(s::StringView) = MemoryView(codeunits(s))
-MemoryKind(::Type{StringView{A}}) where {A} = MemoryKind(A)
 
 end # module

--- a/src/MemoryViews.jl
+++ b/src/MemoryViews.jl
@@ -9,6 +9,7 @@ export MemoryView,
     inner,
     split_each,
     unsafe_from_parts,
+    unsafe_memoryref,
     split_first,
     split_last,
     split_at,
@@ -129,12 +130,29 @@ function unsafe_from_parts(ref::MemoryRef, len::Int)
 end
 
 """
-    Base.memoryref(x::MemoryView{T})::MemoryRef{T}
+    Base.memoryref(x::MutableMemoryView{T})::MemoryRef{T}
 
 Get the `MemoryRef` of `x`. This reference is guaranteed to be inbounds,
 except if `x` is empty, where it may point to one element past the end.
+
+To get the `MemoryRef` from an immutable `MemoryView`, use
+[`unsafe_memoryref]`(@ref)
 """
-Base.memoryref(@nospecialize(x::MemoryView)) = x.ref
+Base.memoryref(@nospecialize(x::MutableMemoryView)) = x.ref
+
+"""
+    unsafe_memoryref(x::MemoryView{T})::MemoryRef{T}
+
+Same as `memoryref(::MutableMemoryView)`, but also works for `ImmutableMemoryView`.
+Users must ensure only to mutate the resulting `MemoryRef` if `x` does not alias
+memory assumed to be immutable.
+
+!!! warning
+    As the resulting `MemoryRef` is mutable, users must take care that this
+    function allows mutation of memory assumed to be immutable, such as
+    the memory backing a `String`. This can cause undefined behavour.
+"""
+unsafe_memoryref(@nospecialize(x::MemoryView)) = x.ref
 
 _get_mutability(::MemoryView{T, M}) where {T, M} = M
 

--- a/src/MemoryViews.jl
+++ b/src/MemoryViews.jl
@@ -70,6 +70,9 @@ This includes the fact that some elements in the array, such as  `String`s,
 may be stored as pointers, and [isbits Union optimisations]
 (https://docs.julialang.org/en/v1/devdocs/isbitsunionarrays/).
 
+`MemoryView{T, M}` is guaranteed to be immutable and to have the same size as a
+`MemoryRef{T}` and an `Int` combined.
+
 """
 struct MemoryView{T, M <: Union{Mutable, Immutable}} <: DenseVector{T}
     # If the memview is empty, there is no guarantees where the ref points to

--- a/src/MemoryViews.jl
+++ b/src/MemoryViews.jl
@@ -3,10 +3,6 @@ module MemoryViews
 export MemoryView,
     ImmutableMemoryView,
     MutableMemoryView,
-    MemoryKind,
-    IsMemory,
-    NotMemory,
-    inner,
     split_each,
     unsafe_from_parts,
     unsafe_memoryref,
@@ -45,8 +41,6 @@ The parameter `M` controls the mutability of the memory view,
 and may be `Mutable` or `Immutable`, corresponding to the
 the aliases `MutableMemoryView{T}` and `ImmutableMemoryView{T}`.
 
-See also: `MemoryKind`
-
 # Examples
 ```jldoctest
 julia> v = view([1, 2, 3, 4], 2:3);
@@ -64,10 +58,6 @@ true
 New types `T` which are backed by dense memory should implement:
 * `MemoryView(x::T)` to construct a memory view from `x`. This should
    always return a `MutableMemoryView` when the memory of `x` is mutable.
-* `MemoryKind(x::T)`, if `T` is semantically equal to its own memory view.
-  Examples of this include `Vector`, `Memory`, and
-  `Base.CodeUnits{UInt8, String}`. If so, `x == MemoryView(x)` should hold.
-
 If `MemoryView(x)` is implemented, then `ImmutableMemoryView(x)` will
 automatically work, even if `MemoryView(x)` returns a mutable view.
 
@@ -173,64 +163,6 @@ end
 function MemoryView{T}(x) where {T}
     return MemoryView(x)::MemoryView{T}
 end
-
-"""
-    MemoryKind
-
-Trait object used to signal if values of a type is semantically equal to their own `MemoryView`.
-If so, `MemoryKind(T)` should return an instance of `IsMemory`,
-else `NotMemory()`. The default implementation `MemoryKind(::Type)` returns `NotMemory()`.
-
-If `MemoryKind(T) isa IsMemory{M}`, the following must hold:
-1. `M` is a concrete subtype of `MemoryView`. To obtain `M` from an `m::IsMemory{M}`,
-    use `inner(m)`.
-2. `MemoryView(::T)` is a valid instance of `M` (except in cases where there can be invalid
-   instances of `T` that instead errors, e.g. uninitialized instances).
-3. `MemoryView(x) == x` for all instances `x::T`
-
-Some objects can be turned into `MemoryView` without being `IsMemory`.
-For example, `MemoryView(::String)` returns a valid `MemoryView` even though
-`MemoryKind(String) === NotMemory()`.
-This is because strings have different semantics than memory views - the latter
-is a dense `AbstractArray` while strings are not, and so the fourth requirement
-`MemoryView(x::String) == x` does not hold.
-
-See also: [`MemoryView`](@ref)
-"""
-abstract type MemoryKind end
-
-"""
-    NotMemory <: MemoryKind
-
-See: [`MemoryKind`](@ref)
-"""
-struct NotMemory <: MemoryKind end
-
-"""
-    IsMemory{T <: MemoryView} <: MemoryKind
-
-See: [`MemoryKind`](@ref)
-"""
-struct IsMemory{T <: MemoryView} <: MemoryKind
-    function IsMemory{T}() where {T}
-        isconcretetype(T) || error("In IsMemory{T}, T must be concrete")
-        return new{T}()
-    end
-end
-IsMemory(T::Type{<:MemoryView}) = IsMemory{T}()
-
-"""
-    inner(::IsMemory{T})
-
-Return `T` from an `IsMemory{T}`.
-
-See: [`MemoryKind`](@ref)
-"""
-inner(::IsMemory{T}) where {T} = T
-
-MemoryKind(::Type) = NotMemory()
-MemoryKind(::Type{Union{}}) = NotMemory()
-MemoryKind(::Type{T}) where {T <: MemoryView} = IsMemory(T)
 
 include("construction.jl")
 include("basic.jl")

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -6,12 +6,13 @@ function Base.setindex!(v::MutableMemoryView{T}, x, i::Int) where {T}
     return v
 end
 
-# The parent method for memoryref was added in 1.12. In versions before that,
-# it can be accessed by reaching into internals.
+# The parent method for MemoryRef was added in 1.12. In versions before that,
+# it can be accessed by reaching into internals. ImmutableMemoryView deliberately
+# uses Base's generic parent(::AbstractArray) method, which returns the view itself.
 @static if VERSION < v"1.12.0-DEV.966"
-    Base.parent(@nospecialize(v::MemoryView)) = v.ref.mem
+    Base.parent(@nospecialize(v::MutableMemoryView)) = v.ref.mem
 else
-    Base.parent(@nospecialize(v::MemoryView)) = parent(v.ref)
+    Base.parent(@nospecialize(v::MutableMemoryView)) = parent(v.ref)
 end
 
 Base.size(@nospecialize(v::MemoryView)) = (v.len,)
@@ -66,7 +67,7 @@ end
 Base.empty(::Type{MemoryView{E, M}}) where {E, M} = unsafe_new_memoryview(M, memoryref(Memory{E}()), 0)
 Base.pointer(x::MemoryView{T}) where {T} = Ptr{T}(pointer(x.ref))
 Base.unsafe_convert(::Type{Ptr{T}}, v::MemoryView{T}) where {T} = pointer(v)
-Base.cconvert(::Type{<:Ptr{T}}, v::MemoryView{T}) where {T} = v.ref
+Base.cconvert(::Type{<:Ptr{T}}, v::MemoryView{T}) where {T} = v
 Base.elsize(::Type{<:MemoryView{T}}) where {T} = Base.elsize(Memory{T})
 Base.sizeof(x::MemoryView) = Base.elsize(typeof(x)) * length(x)
 Base.strides(@nospecialize(::MemoryView)) = (1,)

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -407,18 +407,17 @@ function Base.reverse(mem::MemoryView)
     end
 end
 
-struct ReverseMemoryView{T}
-    # I can't think of a reason to allow mutable memory views here
-    mem::ImmutableMemoryView{T}
+struct ReverseMemoryView{T, M <: Union{Mutable, Immutable}}
+    mem::MemoryView{T, M}
 end
 
-function Iterators.reverse(mem::MemoryView{T}) where {T}
-    return ReverseMemoryView{T}(ImmutableMemoryView(mem))
+function Iterators.reverse(mem::MemoryView)
+    return ReverseMemoryView(mem)
 end
 Iterators.reverse(@nospecialize(x::ReverseMemoryView)) = x.mem
 
 Base.length(@nospecialize(x::ReverseMemoryView)) = length(x.mem)
-Base.eltype(::Type{ReverseMemoryView{T}}) where {T} = T
+Base.eltype(::Type{ReverseMemoryView{T, M}}) where {T, M} = T
 
 function Base.iterate(x::ReverseMemoryView, state = length(x))
     iszero(state) && return nothing

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -1,10 +1,6 @@
 MemoryView(@nospecialize(v::MemoryView)) = v
 
 # Array and Memory
-# Array with more than 1 dimension is not equal to the view, since they have different axes
-MemoryKind(::Type{<:Array{T}}) where {T} = NotMemory()
-MemoryKind(::Type{<:Vector{T}}) where {T} = IsMemory(MutableMemoryView{T})
-MemoryKind(::Type{<:Memory{T}}) where {T} = IsMemory(MutableMemoryView{T})
 MemoryView(A::Memory{T}) where {T} = unsafe_new_memoryview(Mutable, memoryref(A), length(A))
 MemoryView(A::Array{T}) where {T} = unsafe_new_memoryview(Mutable, Base.cconvert(Ptr, A), length(A))
 
@@ -24,36 +20,34 @@ function MemoryView(s::SubString{String})
     return unsafe_new_memoryview(Immutable, newref, ncodeunits(s))
 end
 
-# CodeUnits are semantically IsMemory, but only if the underlying string
-# implements MemoryView, which some AbstractStrings may not
-function MemoryKind(::Type{<:Base.CodeUnits{C, S}}) where {C, S}
-    # Strings are normally immutable. New, mutable string types
-    # would need to overload this method.
-    return hasmethod(MemoryView, (S,)) ? IsMemory(ImmutableMemoryView{C}) : NotMemory()
-end
-
 MemoryView(s::Base.CodeUnits) = MemoryView(s.s)
 
-# SubArrays
-# This is quite tricky, because the indexing can be:
-# * <: AbstractUnitRange
-# * StepRange, with step == 1
-# * Integer (zero-dimensional along one axis)
-
-# It can also be multidimensional, but if so, all axes but the last one
-# must span the entire dimension.
-# And if so, we would need to compute the linear indices.
-
-# For now, I've only accepted 1-D views.
+# SubArrays with fast linear indexing are contiguous when either their first
+# index is an AbstractUnitRange, or all their indices are scalars. Together
+# with the index-tuple restriction, L == true guarantees unit linear stride.
 const ContiguousSubArray = SubArray{
     T, N, P, I, true,
-} where {T, N, P, I <: Union{Tuple{Integer}, Tuple{AbstractUnitRange}}}
+} where {
+    T,
+    N,
+    P,
+    I <: Union{Tuple{AbstractUnitRange, Vararg{Any}}, Tuple{Vararg{Integer}}},
+}
 
-MemoryKind(::Type{<:ContiguousSubArray{T, N, P}}) where {T, N, P} = MemoryKind(P)
+first_parent_index(i::Integer) = i
+first_parent_index(i) = first(i)
 
 function MemoryView(s::ContiguousSubArray{T, N, P}) where {T, N, P}
-    memview = MemoryView(parent(s)::P)
-    inds = only(parentindices(s))
-    @boundscheck checkbounds_lightboundserror(memview.ref.mem, inds)
-    return @inbounds memview[inds]
+    p = parent(s)::P
+    memview = MemoryView(p)::MemoryView{T}
+    isempty(s) && return memview[1:0]
+
+    parent_inds = map(first_parent_index, parentindices(s))
+    linear_inds = LinearIndices(p)
+    parent_start = linear_inds[parent_inds...]
+    start = Int(parent_start - first(linear_inds) + 1)::Int
+    stop = start + length(s) - 1
+
+    @boundscheck checkbounds_lightboundserror(memview, start:stop)
+    return @inbounds memview[start:stop]
 end

--- a/src/delimited.jl
+++ b/src/delimited.jl
@@ -2,13 +2,13 @@
 Iterator struct created by `split_each`.
 Type and parameters are public, but otherwise the interface is defined by `split_each`, 
 """
-struct DelimitedIterator{T, M}
+struct DelimitedIterator{T, M, D}
     v::MemoryView{T, M}
-    d::T
+    d::D
 end
 
 Base.IteratorSize(::Type{<:DelimitedIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{DelimitedIterator{T, M}}) where {T, M} = MemoryView{T, M}
+Base.eltype(::Type{<:DelimitedIterator{T, M}}) where {T, M} = MemoryView{T, M}
 
 function Base.iterate(d::DelimitedIterator, state::Int = 1)
     len = length(d.v)
@@ -36,6 +36,7 @@ end
 Return an iterator over memory-backed data `data` of eltype `T`.
 Returns `MemoryView`s of the same elements as `data`, separated by by `x`.
 Items are compared by `isequal`.
+The delimiter `x` must satisfy `x isa T`.
 
 An empty input `data` yields no elements. Empty elements are otherwise
 yielded.
@@ -52,9 +53,10 @@ julia> split_each(UInt8[], UInt8('b')) |> collect |> print
 MutableMemoryView{UInt8}[]
 ```
 """
-function split_each(x, d::T) where {T}
+function split_each(x, d::D) where {D}
     v = MemoryView(x)::MemoryView
-    eltype(v) == T || error("MemoryView(x) must be of eltype T")
+    T = eltype(v)
+    d isa T || error("Delimiter must be an instance of eltype(MemoryView(x))")
     M = _get_mutability(v)
-    return DelimitedIterator{T, M}(v, d)
+    return DelimitedIterator{T, M, D}(v, d)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,10 +355,18 @@ end
     @test memoryref(ref, 2)[] === 30
 
     imm = MemoryView("abc")[2:3]
-    ref = memoryref(imm)
+    @test_throws MethodError memoryref(imm)
+
+    ref = unsafe_memoryref(imm)
     @test ref === imm.ref
     @test memoryref(ref, 1)[] === UInt8('b')
     @test memoryref(ref, 2)[] === UInt8('c')
+
+    backing = [10, 20, 30]
+    imm = ImmutableMemoryView(backing)[2:3]
+    ref = unsafe_memoryref(imm)
+    memoryref(ref, 1)[] = 50
+    @test backing == [10, 50, 30]
 end
 
 @testset "Misc functions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -768,12 +768,19 @@ end
 
 @testset "Iterators.reverse" begin
     for v in Any[AbstractString["abc", "def", ""], Char['a', 'b'], UInt32[], Int16[9, 2, 1]]
-        mem = MemoryView(v)
-        it = Iterators.reverse(mem)
-        @test length(it) == length(mem)
-        @test collect(it) == reverse(mem)
-        @test Iterators.reverse(it) === ImmutableMemoryView(mem)
+        for mem in (MemoryView(v), ImmutableMemoryView(v))
+            it = Iterators.reverse(mem)
+            @test length(it) == length(mem)
+            @test eltype(it) === eltype(mem)
+            @test collect(it) == reverse(mem)
+            @test Iterators.reverse(it) === mem
+        end
     end
+
+    v = [1, 2, 3]
+    mem = Iterators.reverse(Iterators.reverse(MemoryView(v)))
+    mem[2] = 4
+    @test v == [1, 4, 3]
 end
 
 @testset "split_each" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,41 @@ end
     @test_throws TypeError ImmutableMemoryView{UInt32}(x)
 end
 
+@testset "SubArray construction" begin
+    a = reshape(collect(1:24), 4, 3, 2)
+
+    for s in Any[
+            view(a, 2:4),
+            view(a, :, 2, 1),
+            view(a, :, 2:3, 1),
+            view(a, 2:4, 2, 1),
+            view(a, 1, 2, 1),
+            view(a, Base.IdentityUnitRange(2:4)),
+            view(a, 1:0),
+            view(a, :, :, :),
+        ]
+        mem = MemoryView(s)
+        @test mem isa MutableMemoryView{Int}
+        @test mem == vec(collect(s))
+    end
+
+    # Contiguity must follow from the type. A StepRange is therefore not
+    # accepted even when its runtime step happens to be one.
+    @test_throws MethodError MemoryView(view(a, 1:1:4))
+    @test_throws MethodError MemoryView(view(a, 1:2:4))
+    @test_throws MethodError MemoryView(view(a, 4:-1:2))
+    @test_throws MethodError MemoryView(view(a, 1, :, 1))
+    @test_throws MethodError MemoryView(view(a, 1:2, :, 1))
+
+    @test MemoryView(view(UInt8[0x61], 1)) == UInt8[0x61]
+    @test MemoryView(view(b"abcde", Base.IdentityUnitRange(2:4))) == b"bcd"
+
+    # The index layout is contiguous, but the parent is not memory-backed.
+    range_view = view(reshape(UInt8(1):UInt8(6), 2, 3), 2:4)
+    @test range_view isa MemoryViews.ContiguousSubArray
+    @test_throws MethodError MemoryView(range_view)
+end
+
 @testset "Immutable views are immutable" begin
     mem = MemoryView("abc")
     @test mem isa ImmutableMemoryView{UInt8}
@@ -869,48 +904,20 @@ end
     @test Base.cconvert(Ptr{Int}, v2) === v2.ref
 end
 
-@testset "MemoryKind" begin
-    @test MemoryKind(Vector{Int16}) == IsMemory(MutableMemoryView{Int16})
-    @test MemoryKind(typeof(codeunits(view("abc", 2:3)))) ==
-        IsMemory(ImmutableMemoryView{UInt8})
-    @test MemoryKind(typeof(view(Memory{String}(undef, 3), Base.OneTo(2)))) ==
-        IsMemory(MutableMemoryView{String})
-    @test MemoryKind(Matrix{Nothing}) == NotMemory()
-    @test MemoryKind(Memory{Int32}) == IsMemory(MutableMemoryView{Int32})
-    @test MemoryKind(typeof(view([1], 1:1))) == IsMemory(MutableMemoryView{Int})
-
-    @test MemoryKind(ImmutableMemoryView{Dict}) == IsMemory(ImmutableMemoryView{Dict})
-    @test MemoryKind(MutableMemoryView{UInt32}) == IsMemory(MutableMemoryView{UInt32})
-
-    @test inner(IsMemory(MutableMemoryView{Int32})) == MutableMemoryView{Int32}
-    @test inner(IsMemory(ImmutableMemoryView{Tuple{String, Int}})) ==
-        ImmutableMemoryView{Tuple{String, Int}}
-
-    @test MemoryKind(SubString{String}) == NotMemory()
-    @test MemoryKind(String) == NotMemory()
-    @test MemoryKind(Int) == NotMemory()
-    @test MemoryKind(Nothing) == NotMemory()
-    @test MemoryKind(Union{}) == NotMemory()
-    @test_throws Exception inner(NotMemory())
-end
-
 @testset "StringViews" begin
     # Backed by mutable array
     s = StringView([0x01, 0x02])
     @test MemoryView(s) isa MutableMemoryView{UInt8}
     @test MemoryView(s) == [0x01, 0x02]
-    @test MemoryKind(typeof(s)) == IsMemory{MutableMemoryView{UInt8}}()
 
     # Backed by immutable string data
     s = StringView(view(codeunits("abcd"), 2:4))
     @test MemoryView(s) isa ImmutableMemoryView{UInt8}
     @test MemoryView(s) == codeunits("bcd")
-    @test MemoryKind(typeof(s)) == IsMemory{ImmutableMemoryView{UInt8}}()
 
     # Not backed by memory
     s = StringView(view(0x61:0x65, 2:4))
     @test_throws MethodError MemoryView(s)
-    @test MemoryKind(typeof(s)) == NotMemory()
 end
 
 @testset "FixedSizeArrays" begin
@@ -925,7 +932,6 @@ end
         @test length(mem) == length(A)
         @test mem == vec(A)
         @test typeof(mem) == MutableMemoryView{eltype(A)}
-        @test MemoryKind(typeof(A)) == IsMemory(MutableMemoryView{eltype(A)})
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ MUT_BACKINGS = Any[
     @testset "Unsafe mutability" begin
         v = [1.0, 2.0, 3.0]
         m = ImmutableMemoryView(v)
-        m2 = unsafe_from_parts(m.ref, 3)
+        m2 = unsafe_from_parts(unsafe_memoryref(m), 3)
         m2[2] = 5.0
         @test v == [1.0, 5.0, 3.0]
     end
@@ -99,6 +99,7 @@ end
     @test_throws MethodError MemoryView(view(a, 1, :, 1))
     @test_throws MethodError MemoryView(view(a, 1:2, :, 1))
 
+    @test MemoryView(view([1])) == [1]
     @test MemoryView(view(UInt8[0x61], 1)) == UInt8[0x61]
     @test MemoryView(view(b"abcde", Base.IdentityUnitRange(2:4))) == b"bcd"
 
@@ -174,9 +175,15 @@ end
     for mem in Any[MemoryView([1, 2, 3]), MemoryView("abc"), MemoryView(Float32[1.0])]
         @test strides(mem) === (1,)
         @test IndexStyle(typeof(mem)) === Base.IndexLinear()
-        @test Base.elsize(typeof(mem)) === Base.elsize(typeof(parent(mem)))
+        @test Base.elsize(typeof(mem)) === Base.elsize(Memory{eltype(mem)})
     end
     @test strides(MemoryView(Int[])) === (1,)
+
+    for M in (Mutable, Immutable)
+        T = MemoryView{Int, M}
+        @test !ismutabletype(T)
+        @test sizeof(T) == sizeof(MemoryRef{Int}) + sizeof(Int)
+    end
 end
 
 # Span of views
@@ -385,7 +392,7 @@ end
 @testset "memoryref" begin
     mem = MemoryView([10, 20, 30])[2:3]
     ref = memoryref(mem)
-    @test ref === mem.ref
+    @test ref isa MemoryRef{Int}
     @test memoryref(ref, 1)[] === 20
     @test memoryref(ref, 2)[] === 30
 
@@ -393,7 +400,7 @@ end
     @test_throws MethodError memoryref(imm)
 
     ref = unsafe_memoryref(imm)
-    @test ref === imm.ref
+    @test ref isa MemoryRef{UInt8}
     @test memoryref(ref, 1)[] === UInt8('b')
     @test memoryref(ref, 2)[] === UInt8('c')
 
@@ -420,7 +427,7 @@ end
         @test mem == [9, 3, 4]
         @test mem2 == [2, 10, 4]
         # Only makes a copy of the needed data
-        @test length(mem2.ref.mem) == length(mem2)
+        @test length(parent(mem2)) == length(mem2)
     end
 
     @testset "Parentindices" begin
@@ -530,7 +537,7 @@ end
             mem = MemoryView(v)
             rev = reverse(mem)
             @test typeof(rev) == typeof(mem)
-            @test rev.ref != mem.ref
+            @test memoryref(rev) != memoryref(mem)
             @test rev == reverse(v)
             @test_throws Exception reverse!(ImmutableMemoryView(v))
         end
@@ -558,7 +565,11 @@ end
         vec = Base.wrap(Array, mem, (3,))
         v = MemoryView(vec)
         @test parent(v) === mem
-        @test parent(ImmutableMemoryView(mem)) === mem
+        imm = ImmutableMemoryView(mem)
+        @test parent(imm) === imm
+        @static if VERSION >= v"1.12.0-DEV.966"
+            @test parent(unsafe_memoryref(imm)) === mem
+        end
     end
 
     @testset "Truncate" begin
@@ -838,13 +849,16 @@ end
 
 @testset "Base arrays" begin
     @testset "Memory construction" begin
-        v = ImmutableMemoryView([5, 2, 1])
+        backing = [5, 2, 1]
+        v = ImmutableMemoryView(backing)
         @test Memory(v) isa Memory{Int}
         @test Memory(v) == v
 
-        @test Memory{Int}(v) isa Memory{Int}
-        @test Memory{Int}(v) == v
-        @test Memory{Int}(v) !== parent(v)
+        copied = Memory{Int}(v)
+        @test copied isa Memory{Int}
+        @test copied == v
+        copied[1] = 10
+        @test backing == [5, 2, 1]
 
         @test isempty(Memory{Int}(v[1:0]))
     end
@@ -901,7 +915,11 @@ end
     @test mem isa MutableMemoryView{Int}
 
     v2 = MemoryView([3, 1, 4])
-    @test Base.cconvert(Ptr{Int}, v2) === v2.ref
+    converted = Base.cconvert(Ptr{Int}, v2)
+    @test converted === v2
+    GC.@preserve converted begin
+        @test Base.unsafe_convert(Ptr{Int}, converted) === pointer(v2)
+    end
 end
 
 @testset "StringViews" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -791,6 +791,14 @@ end
     @test eltype(it) == MutableMemoryView{String}
     @test it isa DelimitedIterator{String, Mutable}
 
+    it = split_each(AbstractString["a", "b"], "")
+    @test eltype(it) == MutableMemoryView{AbstractString}
+    @test it isa DelimitedIterator{AbstractString, Mutable, String}
+    @test collect(it) == [["a", "b"]]
+    @test collect(split_each(AbstractString["", "a", "", "b", ""], "")) == [[], ["a"], ["b"], []]
+    @test collect(split_each(Union{Int, Nothing}[1, nothing, 2], nothing)) == [[1], [2]]
+    @test_throws ErrorException split_each([1, 2], 1.0)
+
     @test collect(split_each(b"", 0x00)) == ImmutableMemoryView{UInt8}[]
     @test collect(split_each([1, 2, 3, 3, 4, 5, 2, 3], 3)) == [[1, 2], [], [4, 5, 2], []]
     @test collect(split_each(String[], "")) == String[]


### PR DESCRIPTION
This was unsafe, because the resulting `MemoryRef` allowed mutation of the underlying memory. Hence, users could mutate memory such as `String`, causing undefined behaviour.

Restrict the signature to `MutableMemoryView`, and add `unsafe_memoryref`

Fixes #46
